### PR TITLE
Extract hardcoded Fuse.js threshold into shared FUZZY_SEARCH_THRESHOLD constant (Fixes #273)

### DIFF
--- a/apps/api/src/app/portfolio/portfolio.service.ts
+++ b/apps/api/src/app/portfolio/portfolio.service.ts
@@ -32,6 +32,7 @@ import {
 } from '@ghostfolio/common/calculation-helper';
 import {
   DEFAULT_CURRENCY,
+  FUZZY_SEARCH_THRESHOLD,
   TAG_ID_EMERGENCY_FUND,
   TAG_ID_EXCLUDE_FROM_ANALYSIS,
   UNKNOWN_KEY
@@ -271,7 +272,7 @@ export class PortfolioService {
     if (searchQuery) {
       const fuse = new Fuse(accounts, {
         keys: ['name', 'platform.name'],
-        threshold: 0.3
+        threshold: FUZZY_SEARCH_THRESHOLD
       });
 
       accounts = fuse.search(searchQuery).map(({ item }) => {
@@ -373,7 +374,7 @@ export class PortfolioService {
     if (searchQuery) {
       const fuse = new Fuse(holdings, {
         keys: ['isin', 'name', 'symbol'],
-        threshold: 0.3
+        threshold: FUZZY_SEARCH_THRESHOLD
       });
 
       holdings = fuse.search(searchQuery).map(({ item }) => {

--- a/libs/common/src/lib/config.ts
+++ b/libs/common/src/lib/config.ts
@@ -76,6 +76,8 @@ export const PORTFOLIO_SNAPSHOT_COMPUTATION_QUEUE_PRIORITY_LOW =
   Number.MAX_SAFE_INTEGER;
 
 export const DEFAULT_CURRENCY = 'USD';
+
+export const FUZZY_SEARCH_THRESHOLD = 0.3;
 export const DEFAULT_DATE_FORMAT_MONTH_YEAR = 'MMM yyyy';
 export const DEFAULT_HOST = '0.0.0.0';
 export const DEFAULT_LANGUAGE_CODE = 'en';

--- a/libs/ui/src/lib/assistant/assistant.component.ts
+++ b/libs/ui/src/lib/assistant/assistant.component.ts
@@ -1,3 +1,4 @@
+import { FUZZY_SEARCH_THRESHOLD } from '@ghostfolio/common/config';
 import { getAssetProfileIdentifier } from '@ghostfolio/common/helper';
 import { Filter, PortfolioPosition, User } from '@ghostfolio/common/interfaces';
 import { InternalRoute } from '@ghostfolio/common/routes/interfaces/internal-route.interface';
@@ -735,7 +736,7 @@ export class GfAssistantComponent implements OnChanges, OnDestroy, OnInit {
 
     const fuse = new Fuse(allRoutes, {
       keys: ['title'],
-      threshold: 0.3
+      threshold: FUZZY_SEARCH_THRESHOLD
     });
 
     return fuse.search(searchTerm).map(({ item: { routerLink, title } }) => {


### PR DESCRIPTION
## Summary

Fixes #273

Extracts the hardcoded `0.3` Fuse.js search threshold into a shared `FUZZY_SEARCH_THRESHOLD` constant in `libs/common/src/lib/config.ts`. All three usages across the codebase now reference this constant:

- `portfolio.service.ts` → `getAccountsWithAggregations()` (account search)
- `portfolio.service.ts` → `getHoldings()` (holdings search)
- `assistant.component.ts` → `searchQuickLinks()` (quick link search)

**Root cause:** The threshold value `0.3` was duplicated as a magic number in three separate Fuse.js instantiations, making it easy for them to drift apart and harder to tune globally.

No behavioral change — the threshold value remains `0.3`.

## Review & Testing Checklist for Human

- [ ] Verify no other Fuse.js `threshold` usages were missed (grep for `new Fuse` or `threshold:` in the codebase)
- [ ] Confirm the constant name `FUZZY_SEARCH_THRESHOLD` and its placement in `config.ts` align with project naming conventions (other constants use `DEFAULT_` prefix)

### Notes
- The one other `threshold`-like match in the codebase (`thresholdMax: 0.32` in `emerging-markets.ts`) is unrelated — it's an X-Ray rule threshold, not a Fuse.js search threshold.

Link to Devin session: https://app.devin.ai/sessions/803c10999d2b409c95410f2c0a6bf2f0
Requested by: @JiayanL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jiayanl/ghostfolio/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
