### PR TITLE
Update `SECURITY.md` with vulnerability disclosure process (Fixes #299)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,39 @@
 # Security Policy
 
-## Reporting Security Issues
+## Supported Versions
 
-If you discover a security vulnerability in this repository, please report it to security[at]ghostfol.io. We will acknowledge your report and provide guidance on the next steps.
+We release patches for security vulnerabilities in the following versions:
 
-To help us resolve the issue, please include the following details:
+| Version  | Supported          |
+| -------- | ------------------ |
+| Latest   | :white_check_mark: |
+| < Latest | :x:                |
 
-- A description of the vulnerability
-- Steps to reproduce the vulnerability
+Only the latest release of Ghostfolio receives security updates. We recommend always running the most recent version.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Ghostfolio, please report it responsibly through one of the following channels:
+
+- **GitHub Security Advisories (preferred):** [Report a vulnerability](https://github.com/JiayanL/ghostfolio/security/advisories/new) via GitHub's private reporting feature.
+- **Email:** Send details to security[at]ghostfol.io.
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+### What to Include
+
+To help us investigate and resolve the issue quickly, please provide:
+
+- A description of the vulnerability and its potential impact
+- Detailed steps to reproduce the vulnerability
 - Affected versions of the software
+- Any relevant logs, screenshots, or proof-of-concept code
 
-We appreciate your responsible disclosure and will work to address the issue promptly.
+### What to Expect
+
+- **Acknowledgment:** We will acknowledge receipt of your report within **48 hours**.
+- **Assessment:** We will investigate and provide an initial assessment within **7 days**.
+- **Resolution:** We aim to release a fix within **30 days** of confirming the vulnerability, depending on complexity.
+- **Disclosure:** We will coordinate with you on public disclosure timing. We request that you do not disclose the vulnerability publicly until a fix has been released.
+
+We appreciate your responsible disclosure and your help in keeping Ghostfolio and its users safe.


### PR DESCRIPTION
## Summary

Rewrites `SECURITY.md` to follow GitHub's security advisory best practices. Adds three sections that were missing:

- **Supported Versions** — clarifies that only the latest release receives security patches.
- **Reporting a Vulnerability** — adds GitHub Security Advisories as the preferred private reporting channel (alongside the existing email).
- **What to Expect** — defines response time commitments (48h ack, 7-day assessment, 30-day fix target) and a coordinated disclosure policy.

No code changes — documentation only.

**Root Cause:** The original `SECURITY.md` lacked a structured disclosure process, response timelines, and a supported-versions table, which are recommended by GitHub's security advisory guidelines.

**Triage Analysis:** S (Small) | Confidence: 0.85

## Review & Testing Checklist for Human

- [ ] Verify the response time SLAs (48h / 7d / 30d) are commitments the team can realistically meet
- [ ] Confirm the GitHub Security Advisories link points to the correct repository (`JiayanL/ghostfolio` vs upstream)
- [ ] Confirm the "only latest version supported" policy matches the project's actual support posture

### Notes

- The email contact (`security[at]ghostfol.io`) was preserved from the original file.
- Prettier was run to ensure formatting consistency.

Link to Devin session: https://app.devin.ai/sessions/7c9fb21ab7b948b18df4a833896f74ac
Requested by: @JiayanL