### PR TITLE
feat: add dead-letter queue for `data-gathering` queue jobs (Fixes #745)

### DIFF
--- a/apps/api/src/services/queues/data-gathering/data-gathering.module.ts
+++ b/apps/api/src/services/queues/data-gathering/data-gathering.module.ts
@@ -7,7 +7,10 @@ import { PrismaModule } from '@ghostfolio/api/services/prisma/prisma.module';
 import { PropertyModule } from '@ghostfolio/api/services/property/property.module';
 import { DataGatheringService } from '@ghostfolio/api/services/queues/data-gathering/data-gathering.service';
 import { SymbolProfileModule } from '@ghostfolio/api/services/symbol-profile/symbol-profile.module';
-import { DATA_GATHERING_QUEUE } from '@ghostfolio/common/config';
+import {
+  DATA_GATHERING_DEAD_LETTER_QUEUE,
+  DATA_GATHERING_QUEUE
+} from '@ghostfolio/common/config';
 
 import { BullAdapter } from '@bull-board/api/bullAdapter';
 import { BullBoardModule } from '@bull-board/nestjs';
@@ -28,6 +31,14 @@ import { DataGatheringProcessor } from './data-gathering.processor';
               displayName: 'Data Gathering',
               readOnlyMode: process.env.BULL_BOARD_IS_READ_ONLY !== 'false'
             }
+          }),
+          BullBoardModule.forFeature({
+            adapter: BullAdapter,
+            name: DATA_GATHERING_DEAD_LETTER_QUEUE,
+            options: {
+              displayName: 'Data Gathering (Dead Letter)',
+              readOnlyMode: process.env.BULL_BOARD_IS_READ_ONLY !== 'false'
+            }
           })
         ]
       : []),
@@ -37,6 +48,9 @@ import { DataGatheringProcessor } from './data-gathering.processor';
         max: 1
       },
       name: DATA_GATHERING_QUEUE
+    }),
+    BullModule.registerQueue({
+      name: DATA_GATHERING_DEAD_LETTER_QUEUE
     }),
     ConfigurationModule,
     DataEnhancerModule,
@@ -48,6 +62,6 @@ import { DataGatheringProcessor } from './data-gathering.processor';
     SymbolProfileModule
   ],
   providers: [DataGatheringProcessor, DataGatheringService],
-  exports: [BullModule, DataEnhancerModule, DataGatheringService]
+  exports: [BullModule, DataEnhancerModule, DataGatheringService],
 })
 export class DataGatheringModule {}

--- a/apps/api/src/services/queues/data-gathering/data-gathering.processor.spec.ts
+++ b/apps/api/src/services/queues/data-gathering/data-gathering.processor.spec.ts
@@ -1,0 +1,104 @@
+import { DataGatheringProcessor } from './data-gathering.processor';
+
+describe('DataGatheringProcessor', () => {
+  let processor: DataGatheringProcessor;
+  let mockDeadLetterQueue: { add: jest.Mock };
+  let mockJob: {
+    id: string;
+    name: string;
+    data: Record<string, unknown>;
+    attemptsMade: number;
+    opts: { attempts: number };
+    remove: jest.Mock;
+  };
+
+  beforeEach(() => {
+    mockDeadLetterQueue = {
+      add: jest.fn().mockResolvedValue(undefined)
+    };
+
+    processor = new DataGatheringProcessor(
+      mockDeadLetterQueue as any,
+      null,
+      null,
+      null,
+      null
+    );
+
+    mockJob = {
+      id: 'test-job-1',
+      name: 'GATHER_ASSET_PROFILE',
+      data: { dataSource: 'YAHOO', symbol: 'AAPL' },
+      attemptsMade: 12,
+      opts: { attempts: 12 },
+      remove: jest.fn().mockResolvedValue(undefined)
+    };
+  });
+
+  describe('onFailed', () => {
+    it('should move job to dead-letter queue when all attempts are exhausted', async () => {
+      const error = new Error('Provider timeout');
+
+      await processor.onFailed(mockJob as any, error);
+
+      expect(mockDeadLetterQueue.add).toHaveBeenCalledWith(
+        'GATHER_ASSET_PROFILE',
+        expect.objectContaining({
+          dataSource: 'YAHOO',
+          symbol: 'AAPL',
+          failedReason: 'Provider timeout',
+          originalJobId: 'test-job-1'
+        })
+      );
+      expect(mockJob.remove).toHaveBeenCalled();
+    });
+
+    it('should not move job to dead-letter queue when attempts remain', async () => {
+      mockJob.attemptsMade = 5;
+      const error = new Error('Temporary failure');
+
+      await processor.onFailed(mockJob as any, error);
+
+      expect(mockDeadLetterQueue.add).not.toHaveBeenCalled();
+      expect(mockJob.remove).not.toHaveBeenCalled();
+    });
+
+    it('should include failedAt timestamp in dead-letter job data', async () => {
+      const error = new Error('Network error');
+      const before = new Date().toISOString();
+
+      await processor.onFailed(mockJob as any, error);
+
+      const addCall = mockDeadLetterQueue.add.mock.calls[0];
+      const jobData = addCall[1];
+      expect(jobData.failedAt).toBeDefined();
+      expect(new Date(jobData.failedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(before).getTime()
+      );
+    });
+
+    it('should handle null error gracefully', async () => {
+      await processor.onFailed(mockJob as any, null);
+
+      expect(mockDeadLetterQueue.add).toHaveBeenCalledWith(
+        'GATHER_ASSET_PROFILE',
+        expect.objectContaining({
+          failedReason: undefined,
+          originalJobId: 'test-job-1'
+        })
+      );
+      expect(mockJob.remove).toHaveBeenCalled();
+    });
+
+    it('should default to 1 attempt when opts.attempts is undefined', async () => {
+      mockJob.opts = {} as any;
+      mockJob.attemptsMade = 1;
+      const error = new Error('Failure');
+
+      await processor.onFailed(mockJob as any, error);
+
+      expect(mockDeadLetterQueue.add).toHaveBeenCalled();
+      expect(mockJob.remove).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/services/queues/data-gathering/data-gathering.processor.ts
+++ b/apps/api/src/services/queues/data-gathering/data-gathering.processor.ts
@@ -4,6 +4,7 @@ import { DataGatheringItem } from '@ghostfolio/api/services/interfaces/interface
 import { MarketDataService } from '@ghostfolio/api/services/market-data/market-data.service';
 import { SymbolProfileService } from '@ghostfolio/api/services/symbol-profile/symbol-profile.service';
 import {
+  DATA_GATHERING_DEAD_LETTER_QUEUE,
   DATA_GATHERING_QUEUE,
   DEFAULT_PROCESSOR_GATHER_ASSET_PROFILE_CONCURRENCY,
   DEFAULT_PROCESSOR_GATHER_HISTORICAL_MARKET_DATA_CONCURRENCY,
@@ -13,10 +14,10 @@ import {
 import { DATE_FORMAT, getStartOfUtcDate } from '@ghostfolio/common/helper';
 import { AssetProfileIdentifier } from '@ghostfolio/common/interfaces';
 
-import { Process, Processor } from '@nestjs/bull';
+import { InjectQueue, OnQueueFailed, Process, Processor } from '@nestjs/bull';
 import { Injectable, Logger } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
-import { Job } from 'bull';
+import { Job, Queue } from 'bull';
 import {
   addDays,
   format,
@@ -33,11 +34,32 @@ import { DataGatheringService } from './data-gathering.service';
 @Processor(DATA_GATHERING_QUEUE)
 export class DataGatheringProcessor {
   public constructor(
+    @InjectQueue(DATA_GATHERING_DEAD_LETTER_QUEUE)
+    private readonly deadLetterQueue: Queue,
     private readonly dataGatheringService: DataGatheringService,
     private readonly dataProviderService: DataProviderService,
     private readonly marketDataService: MarketDataService,
     private readonly symbolProfileService: SymbolProfileService
   ) {}
+
+  @OnQueueFailed()
+  public async onFailed(job: Job, error: Error) {
+    if (job.attemptsMade >= (job.opts.attempts ?? 1)) {
+      Logger.warn(
+        `Job ${job.id} (${job.name}) has exhausted all ${job.attemptsMade} attempts. Moving to dead-letter queue.`,
+        'DataGatheringProcessor'
+      );
+
+      await this.deadLetterQueue.add(job.name, {
+        ...job.data,
+        failedAt: new Date().toISOString(),
+        failedReason: error?.message,
+        originalJobId: job.id
+      });
+
+      await job.remove();
+    }
+  }
 
   @Process({
     concurrency: parseInt(

--- a/apps/api/src/services/queues/data-gathering/data-gathering.service.ts
+++ b/apps/api/src/services/queues/data-gathering/data-gathering.service.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '@ghostfolio/api/services/prisma/prisma.service';
 import { PropertyService } from '@ghostfolio/api/services/property/property.service';
 import { SymbolProfileService } from '@ghostfolio/api/services/symbol-profile/symbol-profile.service';
 import {
+  DATA_GATHERING_DEAD_LETTER_QUEUE,
   DATA_GATHERING_QUEUE,
   DATA_GATHERING_QUEUE_PRIORITY_HIGH,
   DATA_GATHERING_QUEUE_PRIORITY_LOW,
@@ -37,6 +38,8 @@ export class DataGatheringService {
   public constructor(
     @Inject('DataEnhancers')
     private readonly dataEnhancers: DataEnhancerInterface[],
+    @InjectQueue(DATA_GATHERING_DEAD_LETTER_QUEUE)
+    private readonly deadLetterQueue: Queue,
     @InjectQueue(DATA_GATHERING_QUEUE)
     private readonly dataGatheringQueue: Queue,
     private readonly dataProviderService: DataProviderService,
@@ -45,6 +48,18 @@ export class DataGatheringService {
     private readonly propertyService: PropertyService,
     private readonly symbolProfileService: SymbolProfileService
   ) {}
+
+  public async getDeadLetterJobs() {
+    return this.deadLetterQueue.getJobs(['waiting', 'active', 'delayed']);
+  }
+
+  public async getDeadLetterJobsCount() {
+    return this.deadLetterQueue.count();
+  }
+
+  public async clearDeadLetterQueue() {
+    return this.deadLetterQueue.empty();
+  }
 
   public async addJobToQueue({
     data,

--- a/libs/common/src/lib/config.ts
+++ b/libs/common/src/lib/config.ts
@@ -62,6 +62,8 @@ export const BULL_BOARD_ROUTE = '/admin/queues';
 export const CACHE_TTL_NO_CACHE = 1;
 export const CACHE_TTL_INFINITE = 0;
 
+export const DATA_GATHERING_DEAD_LETTER_QUEUE =
+  'DATA_GATHERING_DEAD_LETTER_QUEUE';
 export const DATA_GATHERING_QUEUE = 'DATA_GATHERING_QUEUE';
 export const DATA_GATHERING_QUEUE_PRIORITY_HIGH = 1;
 export const DATA_GATHERING_QUEUE_PRIORITY_LOW = Number.MAX_SAFE_INTEGER;
@@ -169,7 +171,8 @@ export const GATHER_ASSET_PROFILE_PROCESS_JOB_OPTIONS: JobOptions = {
     delay: ms('1 minute'),
     type: 'exponential'
   },
-  removeOnComplete: true
+  removeOnComplete: true,
+  removeOnFail: false
 };
 
 export const GATHER_HISTORICAL_MARKET_DATA_PROCESS_JOB_NAME =
@@ -180,7 +183,8 @@ export const GATHER_HISTORICAL_MARKET_DATA_PROCESS_JOB_OPTIONS: JobOptions = {
     delay: ms('1 minute'),
     type: 'exponential'
   },
-  removeOnComplete: true
+  removeOnComplete: true,
+  removeOnFail: false
 };
 
 export const INVESTMENT_ACTIVITY_TYPES = [


### PR DESCRIPTION
## Summary

Fixes #745 (COG-626)

When `data-gathering` queue jobs exhaust all 12 retry attempts, they previously just sat in the "failed" state with no separate mechanism for inspection or alerting. This PR adds a dedicated dead-letter queue (`DATA_GATHERING_DEAD_LETTER_QUEUE`) so that permanently failed jobs are moved to a separate queue for visibility and manual triage.

**What changed:**
- **Config**: New `DATA_GATHERING_DEAD_LETTER_QUEUE` constant; explicit `removeOnFail: false` on both job option sets
- **Module**: Registers the DLQ with Bull and exposes it in Bull Board (when enabled)
- **Processor**: `@OnQueueFailed()` handler moves jobs to the DLQ once `attemptsMade >= opts.attempts`, preserving the original job data plus `failedAt`, `failedReason`, and `originalJobId` metadata. The original failed job is then removed.
- **Service**: Three new public methods (`getDeadLetterJobs`, `getDeadLetterJobsCount`, `clearDeadLetterQueue`) for internal/future admin use
- **Tests**: 5 new unit tests for the `onFailed` handler

## Review & Testing Checklist for Human

- [ ] **Verify `@OnQueueFailed()` fires correctly on final attempt only**: Bull calls this handler on *every* failure (including intermediate retries). The guard `job.attemptsMade >= (job.opts.attempts ?? 1)` must correctly distinguish final failures from retriable ones. Worth tracing through Bull's source or testing with a real Redis instance.
- [ ] **Atomicity of DLQ move**: `deadLetterQueue.add()` and `job.remove()` are two separate async calls. If the add succeeds but remove fails (e.g., Redis blip), the job could exist in both queues. Decide if this edge case matters for your deployment.
- [ ] **DLQ has no processor**: Jobs added to the dead-letter queue will accumulate in "waiting" state indefinitely. Confirm this is the desired behavior (manual inspection via Bull Board) vs. needing a cleanup/alerting mechanism.
- [ ] **DLQ management methods are not yet exposed via API**: `getDeadLetterJobs()`, `clearDeadLetterQueue()`, etc. are on the service but no controller endpoint wires them up. If admin API access is needed, that's a follow-up.

**Suggested test plan:** Spin up the app with Redis, trigger a data-gathering job for a symbol that will fail (e.g., invalid data source), and observe via Bull Board that the job appears in the "Data Gathering (Dead Letter)" queue after exhausting retries.

### Notes
- `removeOnFail: false` is technically Bull's default, so the config change is explicit/documentary rather than behavioral.
- Triage confidence: 0.65 · Complexity: M

Link to Devin session: https://app.devin.ai/sessions/0c76fb667485450180bb54a753a3994d
Requested by: @JiayanL