### PR TITLE
fix(deps): upgrade helmet from 7.0.0 to 8.1.0 — Fixes #748

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "fast-redact": "3.5.0",
         "fuse.js": "7.1.0",
         "google-spreadsheet": "3.2.0",
-        "helmet": "7.0.0",
+        "helmet": "8.1.0",
         "http-status-codes": "2.3.0",
         "ionicons": "8.0.13",
         "jsonpath": "1.2.1",
@@ -21678,12 +21678,12 @@
       }
     },
     "node_modules/helmet": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.0.0.tgz",
-      "integrity": "sha512-MsIgYmdBh460ZZ8cJC81q4XJknjG567wzEmv46WOBblDb6TUd3z8/GhgmsM9pn8g2B80tAJ4m5/d3Bi1KrSUBQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
       "license": "MIT",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/homedir-polyfill": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "fast-redact": "3.5.0",
     "fuse.js": "7.1.0",
     "google-spreadsheet": "3.2.0",
-    "helmet": "7.0.0",
+    "helmet": "8.1.0",
     "http-status-codes": "2.3.0",
     "ionicons": "8.0.13",
     "jsonpath": "1.2.1",


### PR DESCRIPTION
## Summary

Upgrades the `helmet` middleware dependency from `7.0.0` to `8.1.0` (latest). Fixes #748.

Only `package.json` and `package-lock.json` are changed — no application code modifications were needed. The existing CSP configuration in `apps/api/src/main.ts` already uses properly quoted directive values (`'self'`, `'unsafe-inline'`), which is compatible with helmet v8's stricter validation.

**Key behavioral changes in helmet v8:**
- `Strict-Transport-Security` default max-age increased from 180 → 365 days
- `Content-Security-Policy` now **throws** (previously warned) on unquoted directives (e.g. `self` vs `'self'`)
- Minimum Node version bumped from 16 → 18

## Triage Analysis
| Field | Value |
|---|---|
| Complexity | S |
| Confidence | 0.9 |

## Review & Testing Checklist for Human
- [ ] Verify the project's Node.js version is ≥ 18 in CI and production environments (helmet v8 drops Node 16/17 support)
- [ ] Confirm the increased HSTS max-age (180 → 365 days) is acceptable for production — browsers will cache the HSTS policy for a full year
- [ ] Spot-check that the app boots cleanly with `ENABLE_FEATURE_SUBSCRIPTION=true` (the code path that invokes `helmet()` with CSP config in `apps/api/src/main.ts:78-89`)

**Suggested test plan:** Start the API server locally and verify HTTP response headers (e.g. `curl -I`) include the expected `Strict-Transport-Security` and `Content-Security-Policy` headers without errors.

### Notes
- Local test suite could not run due to pre-existing missing env vars (`ACCESS_TOKEN_SALT`, etc.) — this is unrelated to the helmet change.
- Lint (`nx lint api`) passes cleanly (only pre-existing warnings).

Link to Devin session: https://app.devin.ai/sessions/3ba45f4b6cee4b6e924b22dad7c10dc0
Requested by: @JiayanL