### PR TITLE
fix: add null/undefined currency checks to prevent 'nullEUR' exchange rate errors (Fixes #752)

### DIFF
--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.spec.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.spec.ts
@@ -1,0 +1,121 @@
+import { Logger } from '@nestjs/common';
+
+import { ExchangeRateDataService } from './exchange-rate-data.service';
+
+describe('ExchangeRateDataService', () => {
+  let exchangeRateDataService: ExchangeRateDataService;
+
+  beforeEach(() => {
+    exchangeRateDataService = new ExchangeRateDataService(
+      null,
+      null,
+      null,
+      null
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('toCurrency', () => {
+    it('should return 0 if value is 0', () => {
+      expect(exchangeRateDataService.toCurrency(0, 'USD', 'EUR')).toBe(0);
+    });
+
+    it('should return the value and warn if fromCurrency is null', () => {
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+
+      expect(exchangeRateDataService.toCurrency(100, null, 'EUR')).toBe(100);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Missing currency: fromCurrency=null, toCurrency=EUR',
+        'ExchangeRateDataService'
+      );
+    });
+
+    it('should return the value and warn if fromCurrency is undefined', () => {
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+
+      expect(exchangeRateDataService.toCurrency(100, undefined, 'EUR')).toBe(
+        100
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Missing currency: fromCurrency=undefined, toCurrency=EUR',
+        'ExchangeRateDataService'
+      );
+    });
+
+    it('should return the value and warn if toCurrency is null', () => {
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+
+      expect(exchangeRateDataService.toCurrency(100, 'USD', null)).toBe(100);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Missing currency: fromCurrency=USD, toCurrency=null',
+        'ExchangeRateDataService'
+      );
+    });
+
+    it('should return the value and warn if toCurrency is undefined', () => {
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+
+      expect(exchangeRateDataService.toCurrency(100, 'USD', undefined)).toBe(
+        100
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Missing currency: fromCurrency=USD, toCurrency=undefined',
+        'ExchangeRateDataService'
+      );
+    });
+
+    it('should return the value if fromCurrency equals toCurrency', () => {
+      expect(exchangeRateDataService.toCurrency(100, 'EUR', 'EUR')).toBe(100);
+    });
+  });
+
+  describe('toCurrencyAtDate', () => {
+    it('should return 0 if value is 0', async () => {
+      expect(
+        await exchangeRateDataService.toCurrencyAtDate(
+          0,
+          'USD',
+          'EUR',
+          new Date()
+        )
+      ).toBe(0);
+    });
+
+    it('should return undefined and warn if fromCurrency is null', async () => {
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+
+      expect(
+        await exchangeRateDataService.toCurrencyAtDate(
+          100,
+          null,
+          'EUR',
+          new Date()
+        )
+      ).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Missing currency: fromCurrency=null, toCurrency=EUR',
+        'ExchangeRateDataService'
+      );
+    });
+
+    it('should return undefined and warn if toCurrency is undefined', async () => {
+      const warnSpy = jest.spyOn(Logger, 'warn').mockImplementation();
+
+      expect(
+        await exchangeRateDataService.toCurrencyAtDate(
+          100,
+          'USD',
+          undefined,
+          new Date()
+        )
+      ).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Missing currency: fromCurrency=USD, toCurrency=undefined',
+        'ExchangeRateDataService'
+      );
+    });
+  });
+});

--- a/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
+++ b/apps/api/src/services/exchange-rate-data/exchange-rate-data.service.ts
@@ -70,7 +70,7 @@ export class ExchangeRateDataService {
       [currency: string]: { [dateString: string]: number };
     } = {};
 
-    for (const currency of currencies) {
+    for (const currency of currencies.filter(Boolean)) {
       exchangeRatesByCurrency[`${currency}${targetCurrency}`] =
         await this.getExchangeRates({
           startDate,
@@ -229,6 +229,15 @@ export class ExchangeRateDataService {
       return 0;
     }
 
+    if (!aFromCurrency || !aToCurrency) {
+      Logger.warn(
+        `Missing currency: fromCurrency=${aFromCurrency}, toCurrency=${aToCurrency}`,
+        'ExchangeRateDataService'
+      );
+
+      return aValue;
+    }
+
     let factor: number;
 
     if (aFromCurrency === aToCurrency) {
@@ -269,6 +278,15 @@ export class ExchangeRateDataService {
   ) {
     if (aValue === 0) {
       return 0;
+    }
+
+    if (!aFromCurrency || !aToCurrency) {
+      Logger.warn(
+        `Missing currency: fromCurrency=${aFromCurrency}, toCurrency=${aToCurrency}`,
+        'ExchangeRateDataService'
+      );
+
+      return undefined;
     }
 
     if (isToday(aDate)) {
@@ -513,7 +531,12 @@ export class ExchangeRateDataService {
       await this.prismaService.symbolProfile.findMany({
         distinct: ['currency'],
         orderBy: [{ currency: 'asc' }],
-        select: { currency: true }
+        select: { currency: true },
+        where: {
+          currency: {
+            not: null
+          }
+        }
       })
     ).forEach(({ currency }) => {
       currencies.push(currency);


### PR DESCRIPTION
## Summary

Fixes #752 — Docker logs show repeated `No exchange rate has been found for nullEUR` errors.

**Root cause:** When a `SymbolProfile` has a `null` currency in the database, that null value propagates through exchange rate lookups. The template literal `${fromCurrency}${toCurrency}` produces keys like `nullEUR`, which fail lookup and trigger noisy ERROR logs.

**Changes (all in `exchange-rate-data.service.ts`):**
- **`toCurrency()`** — early return with `Logger.warn` if either currency arg is null/undefined (returns original value unconverted)
- **`toCurrencyAtDate()`** — same guard, returns `undefined` (matches existing fallback pattern of this method)
- **`getExchangeRatesByCurrency()`** — `.filter(Boolean)` on the currencies loop to skip null entries
- **`prepareCurrencies()`** — added `where: { currency: { not: null } }` to the `symbolProfile.findMany` query, matching the existing pattern on the `account.findMany` query directly above it

New test file with 9 regression tests covering null/undefined currency arguments for both `toCurrency` and `toCurrencyAtDate`.

## Review & Testing Checklist for Human

- [ ] **Verify return-value behavior is safe for callers**: `toCurrency` returns the unconverted `aValue` on null currency (not 0, not undefined). Confirm callers in `portfolio.service.ts`, `account.service.ts`, etc. handle receiving an unconverted value without producing silently wrong calculations. This is the highest-risk aspect of this PR.
- [ ] **Severity downgrade from ERROR → WARN**: The original code reached `Logger.error` for these cases. Now they're caught earlier as `Logger.warn`. Confirm this doesn't hide legitimate data issues that ops teams rely on ERROR-level alerts for.
- [ ] **`toCurrencyAtDate` returns `undefined` on null currency**: Verify callers (e.g., `portfolio.service.ts:198`, `:207`) handle `undefined` return without NaN propagation.

### Notes
- The `symbolProfile.findMany` query previously had no `where` clause filtering nulls, while the `account.findMany` query 10 lines above already filtered `currency: { not: null }`. This was likely an oversight in the original code.
- `.filter(Boolean)` in `getExchangeRatesByCurrency` also filters empty strings — this is intentional defensive behavior.
- Triage: Complexity S, Confidence 0.80

Link to Devin session: https://app.devin.ai/sessions/eefe5e2d4fde48acb2222af0f976cb8c
Requested by: @JiayanL