### PR TITLE
fix: add migration path documentation to deprecated fields in PortfolioPosition interface (Fixes #744)

### DIFF
--- a/libs/common/src/lib/interfaces/portfolio-position.interface.spec.ts
+++ b/libs/common/src/lib/interfaces/portfolio-position.interface.spec.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('PortfolioPosition interface', () => {
+  let source: string;
+
+  beforeAll(() => {
+    source = fs.readFileSync(
+      path.join(__dirname, 'portfolio-position.interface.ts'),
+      'utf-8'
+    );
+  });
+
+  describe('Deprecated fields migration path documentation', () => {
+    const deprecatedFields = [
+      'assetClass',
+      'assetClassLabel',
+      'assetSubClass',
+      'assetSubClassLabel',
+      'countries',
+      'currency',
+      'dataSource',
+      'holdings',
+      'name',
+      'sectors',
+      'symbol',
+      'url'
+    ];
+
+    it.each(deprecatedFields)(
+      'should document migration path for deprecated field "%s"',
+      (field) => {
+        const pattern = new RegExp(
+          `@deprecated[^*]*assetProfile[^*]*\\.${field}[^*]*instead[\\s\\S]*?\\b${field}[?]?:`
+        );
+
+        expect(source).toMatch(pattern);
+      }
+    );
+
+    it('should have migration path for all deprecated fields', () => {
+      const bareDeprecatedPattern = /\/\*\*\s*@deprecated\s*\*\//g;
+      const bareMatches = source.match(bareDeprecatedPattern);
+
+      expect(bareMatches).toBeNull();
+    });
+  });
+});

--- a/libs/common/src/lib/interfaces/portfolio-position.interface.ts
+++ b/libs/common/src/lib/interfaces/portfolio-position.interface.ts
@@ -11,10 +11,10 @@ export interface PortfolioPosition {
   activitiesCount: number;
   allocationInPercentage: number;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.assetClass instead */
   assetClass?: AssetClass;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.assetClassLabel instead */
   assetClassLabel?: string;
 
   assetProfile: Pick<
@@ -34,19 +34,19 @@ export interface PortfolioPosition {
     assetSubClassLabel?: string;
   };
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.assetSubClass instead */
   assetSubClass?: AssetSubClass;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.assetSubClassLabel instead */
   assetSubClassLabel?: string;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.countries instead */
   countries: Country[];
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.currency instead */
   currency: string;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.dataSource instead */
   dataSource: DataSource;
 
   dateOfFirstActivity: Date;
@@ -57,7 +57,7 @@ export interface PortfolioPosition {
   grossPerformancePercentWithCurrencyEffect: number;
   grossPerformanceWithCurrencyEffect: number;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.holdings instead */
   holdings: Holding[];
 
   investment: number;
@@ -67,7 +67,7 @@ export interface PortfolioPosition {
   markets?: { [key in Market]: number };
   marketsAdvanced?: { [key in MarketAdvanced]: number };
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.name instead */
   name: string;
 
   netPerformance: number;
@@ -76,16 +76,16 @@ export interface PortfolioPosition {
   netPerformanceWithCurrencyEffect: number;
   quantity: number;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.sectors instead */
   sectors: Sector[];
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.symbol instead */
   symbol: string;
 
   tags?: Tag[];
   type?: string;
 
-  /** @deprecated */
+  /** @deprecated Use {@link PortfolioPosition.assetProfile}.url instead */
   url?: string;
 
   valueInBaseCurrency?: number;


### PR DESCRIPTION
## Summary

Updates all 12 `@deprecated` JSDoc comments in the `PortfolioPosition` interface to include migration path documentation. Previously, each deprecated field was annotated with a bare `/** @deprecated */` that gave no guidance on what to use instead. Each now points to the corresponding property in `assetProfile` (e.g., `Use {@link PortfolioPosition.assetProfile}.currency instead`).

Adds a regression test that reads the interface source and verifies every deprecated field includes a migration path, and that no bare `@deprecated` tags remain.

Fixes #744

### Triage Analysis
| Field | Value |
|---|---|
| Complexity | XL |
| Confidence | 0.5 |
| Risk | High |

## Review & Testing Checklist for Human

- [ ] **Confirm the intent matches expectations**: The "typo" in the issue title is interpreted as the incomplete `@deprecated` annotations lacking migration guidance. Verify this is what was actually wanted — there is no spelling typo being fixed.
- [ ] **Verify `{@link}` syntax renders correctly** in your IDE / docs tooling. The pattern `{@link PortfolioPosition.assetProfile}.fieldName` is slightly unconventional — check that hover tooltips / generated docs resolve the link properly.
- [ ] **Evaluate the test approach**: The regression test reads the `.ts` source as a string and regex-matches it. This is functional but brittle to comment reformatting. Decide if this testing style is acceptable for the project or if it should be removed/replaced.
- [ ] **Spot-check the field→assetProfile mapping**: Confirm each of the 12 deprecated fields actually exists in the `assetProfile` Pick type (they do based on lines 20-35 of the interface, but worth a glance).

**Suggested test plan**: Open the interface file in your IDE, hover over a deprecated field (e.g., `currency`), and confirm the deprecation message with migration path appears. Run `npm run test:common` and verify the new tests pass (expect 2 pre-existing failures in `helper.spec.ts` unrelated to this change).

### Notes
- Only JSDoc comments were changed — zero functional/runtime impact.
- Pre-existing test failures in `helper.spec.ts` (locale-related) are unrelated to this PR.

Link to Devin session: https://app.devin.ai/sessions/57f4e140607942d28913ac09c43b2ae9
Requested by: @JiayanL