### PR TITLE
Add HEALTHCHECK instruction to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,5 +62,6 @@ COPY --chown=node:node --from=builder /ghostfolio/dist/apps /ghostfolio/apps/
 COPY --chown=node:node ./docker/entrypoint.sh /ghostfolio/
 WORKDIR /ghostfolio/apps/api
 EXPOSE ${PORT:-3333}
+HEALTHCHECK CMD curl -f http://localhost:${PORT:-3333}/api/v1/health || exit 1
 USER node
 CMD [ "/ghostfolio/entrypoint.sh" ]


### PR DESCRIPTION
## What

Adds a `HEALTHCHECK` instruction to the Dockerfile.

## Why

The app exposes a `/api/v1/health` endpoint but the Dockerfile lacked a `HEALTHCHECK` instruction, preventing Docker and container orchestration tools (e.g. Kubernetes, Docker Compose health checks) from detecting unhealthy containers.

Since `curl` is already installed in the runtime image, no additional dependencies are required.

```dockerfile
HEALTHCHECK CMD curl -f http://localhost:${PORT:-3333}/api/v1/health || exit 1
