### PR TITLE
Fix: update Bootstrap version from 4.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "ai": "4.3.16",
     "alphavantage": "2.2.0",
     "big.js": "7.0.1",
-    "bootstrap": "4.6.2",
+    "bootstrap": "5.3.8",
     "bull": "4.16.5",
     "chart.js": "4.5.1",
     "chartjs-adapter-date-fns": "3.0.0",


### PR DESCRIPTION
Updated the Bootstrap dependency from v4.6.2 to the latest stable version to address outdated dependency concerns.

Changes made:
Updated version in package.json

This helps ensure better compatibility, security, and access to newer features.

Fixes #2083